### PR TITLE
Comment to make sure people rename AeroLoad

### DIFF
--- a/src/ReplicatedFirst/AeroLoad.localscript.lua
+++ b/src/ReplicatedFirst/AeroLoad.localscript.lua
@@ -9,6 +9,11 @@
 	
 	The following code shows how to do this with a custom GUI,
 	but you will have to fill in some of the code yourself.
+
+	IF YOU USE THIS CODE, MAKE SURE TO PUT IT IN A FILE NAMED 
+	SOMETHING OTHER THAN 'AeroLoad' SO FUTURE FRAMEWORK UPDATES 
+	DO NOT OVERWRITE YOUR CUSTOM 'AeroLoad' SCRIPT. YOU CAN NAME 
+	IT ANYTHING, LIKE 'MyCustomAeroLoad'
 	
 ]]
 


### PR DESCRIPTION
Someone submitted a pull request about framework updates overwriting their implimentation of AeroLoad, not thinking about future framework updates. Comment simply tells the reader to make sure they rename the file so it does not get overwritten.